### PR TITLE
Remove external cloud provider references from Kubernetes control pla…

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -263,7 +263,6 @@ start() {
             --storage-backend=etcd3 \
             --storage-media-type=application/json \
             --v=0 \
-            --cloud-provider=external \
             --service-account-issuer=https://kubernetes.default.svc.cluster.local \
             --service-account-key-file=/tmp/sa.pub \
             --service-account-signing-key-file=/tmp/sa.key &
@@ -306,7 +305,6 @@ start() {
             --hostname-override=$(hostname) \
             --pod-infra-container-image=registry.k8s.io/pause:3.10 \
             --node-ip=$HOST_IP \
-            --cloud-provider=external \
             --cgroup-driver=cgroupfs \
             --max-pods=4  \
             --v=1 &
@@ -321,7 +319,6 @@ start() {
         sudo PATH=$PATH:/opt/cni/bin:/usr/sbin kubebuilder/bin/kube-controller-manager \
             --kubeconfig=/var/lib/kubelet/kubeconfig \
             --leader-elect=false \
-            --cloud-provider=external \
             --service-cluster-ip-range=10.0.0.0/24 \
             --cluster-name=kubernetes \
             --root-ca-file=/var/lib/kubelet/ca.crt \


### PR DESCRIPTION
…ne setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified cluster startup by removing external cloud-provider configuration from core components.
  * Default behavior no longer integrates with an external cloud provider during initialization.
  * Users relying on cloud-specific features (e.g., load balancers, node discovery) should verify functionality under the new defaults and adjust their setup if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->