### PR TITLE
Add manifests for static pods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+kubebuilder
+etcd

--- a/debug-pod.yaml
+++ b/debug-pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: debug-perf
+  namespace: default
+spec:
+  hostPID: true
+  hostNetwork: true
+  containers:
+  - name: perf-debug
+    image: verizondigital/kubectl-flame:v0.2.4-perf
+    command: ["/bin/sleep", "3600"]
+    securityContext:
+      privileged: true
+      capabilities:
+        add: ["SYS_ADMIN", "SYS_PTRACE"]
+  hostPID: true
+  hostNetwork: true

--- a/flame.svg
+++ b/flame.svg
@@ -1,0 +1,828 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" width="1200" height="630" onload="init(evt)" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<!-- Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples. -->
+<!-- NOTES:  -->
+<defs>
+	<linearGradient id="background" y1="0" y2="1" x1="0" x2="0" >
+		<stop stop-color="#eeeeee" offset="5%" />
+		<stop stop-color="#eeeeb0" offset="95%" />
+	</linearGradient>
+</defs>
+<style type="text/css">
+	text { font-family:Verdana; font-size:12px; fill:rgb(0,0,0); }
+	#search, #ignorecase { opacity:0.1; cursor:pointer; }
+	#search:hover, #search.show, #ignorecase:hover, #ignorecase.show { opacity:1; }
+	#subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
+	#title { text-anchor:middle; font-size:17px}
+	#unzoom { cursor:pointer; }
+	#frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
+	.hide { display:none; }
+	.parent { opacity:0.5; }
+</style>
+<script type="text/ecmascript">
+<![CDATA[
+	"use strict";
+	var details, searchbtn, unzoombtn, matchedtxt, svg, searching, currentSearchTerm, ignorecase, ignorecaseBtn;
+	function init(evt) {
+		details = document.getElementById("details").firstChild;
+		searchbtn = document.getElementById("search");
+		ignorecaseBtn = document.getElementById("ignorecase");
+		unzoombtn = document.getElementById("unzoom");
+		matchedtxt = document.getElementById("matched");
+		svg = document.getElementsByTagName("svg")[0];
+		searching = 0;
+		currentSearchTerm = null;
+
+		// use GET parameters to restore a flamegraphs state.
+		var params = get_params();
+		if (params.x && params.y)
+			zoom(find_group(document.querySelector('[x="' + params.x + '"][y="' + params.y + '"]')));
+                if (params.s) search(params.s);
+	}
+
+	// event listeners
+	window.addEventListener("click", function(e) {
+		var target = find_group(e.target);
+		if (target) {
+			if (target.nodeName == "a") {
+				if (e.ctrlKey === false) return;
+				e.preventDefault();
+			}
+			if (target.classList.contains("parent")) unzoom();
+			zoom(target);
+			if (!document.querySelector('.parent')) {
+				clearzoom();
+				return;
+			}
+
+			// set parameters for zoom state
+			var el = target.querySelector("rect");
+			if (el && el.attributes && el.attributes.y && el.attributes._orig_x) {
+				var params = get_params()
+				params.x = el.attributes._orig_x.value;
+				params.y = el.attributes.y.value;
+				history.replaceState(null, null, parse_params(params));
+			}
+		}
+		else if (e.target.id == "unzoom") clearzoom();
+		else if (e.target.id == "search") search_prompt();
+		else if (e.target.id == "ignorecase") toggle_ignorecase();
+	}, false)
+
+	// mouse-over for info
+	// show
+	window.addEventListener("mouseover", function(e) {
+		var target = find_group(e.target);
+		if (target) details.nodeValue = "Function: " + g_to_text(target);
+	}, false)
+
+	// clear
+	window.addEventListener("mouseout", function(e) {
+		var target = find_group(e.target);
+		if (target) details.nodeValue = ' ';
+	}, false)
+
+	// ctrl-F for search
+	// ctrl-I to toggle case-sensitive search
+	window.addEventListener("keydown",function (e) {
+		if (e.keyCode === 114 || (e.ctrlKey && e.keyCode === 70)) {
+			e.preventDefault();
+			search_prompt();
+		}
+		else if (e.ctrlKey && e.keyCode === 73) {
+			e.preventDefault();
+			toggle_ignorecase();
+		}
+	}, false)
+
+	// functions
+	function get_params() {
+		var params = {};
+		var paramsarr = window.location.search.substr(1).split('&');
+		for (var i = 0; i < paramsarr.length; ++i) {
+			var tmp = paramsarr[i].split("=");
+			if (!tmp[0] || !tmp[1]) continue;
+			params[tmp[0]]  = decodeURIComponent(tmp[1]);
+		}
+		return params;
+	}
+	function parse_params(params) {
+		var uri = "?";
+		for (var key in params) {
+			uri += key + '=' + encodeURIComponent(params[key]) + '&';
+		}
+		if (uri.slice(-1) == "&")
+			uri = uri.substring(0, uri.length - 1);
+		if (uri == '?')
+			uri = window.location.href.split('?')[0];
+		return uri;
+	}
+	function find_child(node, selector) {
+		var children = node.querySelectorAll(selector);
+		if (children.length) return children[0];
+	}
+	function find_group(node) {
+		var parent = node.parentElement;
+		if (!parent) return;
+		if (parent.id == "frames") return node;
+		return find_group(parent);
+	}
+	function orig_save(e, attr, val) {
+		if (e.attributes["_orig_" + attr] != undefined) return;
+		if (e.attributes[attr] == undefined) return;
+		if (val == undefined) val = e.attributes[attr].value;
+		e.setAttribute("_orig_" + attr, val);
+	}
+	function orig_load(e, attr) {
+		if (e.attributes["_orig_"+attr] == undefined) return;
+		e.attributes[attr].value = e.attributes["_orig_" + attr].value;
+		e.removeAttribute("_orig_"+attr);
+	}
+	function g_to_text(e) {
+		var text = find_child(e, "title").firstChild.nodeValue;
+		return (text)
+	}
+	function g_to_func(e) {
+		var func = g_to_text(e);
+		// if there's any manipulation we want to do to the function
+		// name before it's searched, do it here before returning.
+		return (func);
+	}
+	function update_text(e) {
+		var r = find_child(e, "rect");
+		var t = find_child(e, "text");
+		var w = parseFloat(r.attributes.width.value) -3;
+		var txt = find_child(e, "title").textContent.replace(/\([^(]*\)$/,"");
+		t.attributes.x.value = parseFloat(r.attributes.x.value) + 3;
+
+		// Smaller than this size won't fit anything
+		if (w < 2 * 12 * 0.59) {
+			t.textContent = "";
+			return;
+		}
+
+		t.textContent = txt;
+		// Fit in full text width
+		if (/^ *$/.test(txt) || t.getSubStringLength(0, txt.length) < w)
+			return;
+
+		for (var x = txt.length - 2; x > 0; x--) {
+			if (t.getSubStringLength(0, x + 2) <= w) {
+				t.textContent = txt.substring(0, x) + "..";
+				return;
+			}
+		}
+		t.textContent = "";
+	}
+
+	// zoom
+	function zoom_reset(e) {
+		if (e.attributes != undefined) {
+			orig_load(e, "x");
+			orig_load(e, "width");
+		}
+		if (e.childNodes == undefined) return;
+		for (var i = 0, c = e.childNodes; i < c.length; i++) {
+			zoom_reset(c[i]);
+		}
+	}
+	function zoom_child(e, x, ratio) {
+		if (e.attributes != undefined) {
+			if (e.attributes.x != undefined) {
+				orig_save(e, "x");
+				e.attributes.x.value = (parseFloat(e.attributes.x.value) - x - 10) * ratio + 10;
+				if (e.tagName == "text")
+					e.attributes.x.value = find_child(e.parentNode, "rect[x]").attributes.x.value + 3;
+			}
+			if (e.attributes.width != undefined) {
+				orig_save(e, "width");
+				e.attributes.width.value = parseFloat(e.attributes.width.value) * ratio;
+			}
+		}
+
+		if (e.childNodes == undefined) return;
+		for (var i = 0, c = e.childNodes; i < c.length; i++) {
+			zoom_child(c[i], x - 10, ratio);
+		}
+	}
+	function zoom_parent(e) {
+		if (e.attributes) {
+			if (e.attributes.x != undefined) {
+				orig_save(e, "x");
+				e.attributes.x.value = 10;
+			}
+			if (e.attributes.width != undefined) {
+				orig_save(e, "width");
+				e.attributes.width.value = parseInt(svg.width.baseVal.value) - (10 * 2);
+			}
+		}
+		if (e.childNodes == undefined) return;
+		for (var i = 0, c = e.childNodes; i < c.length; i++) {
+			zoom_parent(c[i]);
+		}
+	}
+	function zoom(node) {
+		var attr = find_child(node, "rect").attributes;
+		var width = parseFloat(attr.width.value);
+		var xmin = parseFloat(attr.x.value);
+		var xmax = parseFloat(xmin + width);
+		var ymin = parseFloat(attr.y.value);
+		var ratio = (svg.width.baseVal.value - 2 * 10) / width;
+
+		// XXX: Workaround for JavaScript float issues (fix me)
+		var fudge = 0.0001;
+
+		unzoombtn.classList.remove("hide");
+
+		var el = document.getElementById("frames").children;
+		for (var i = 0; i < el.length; i++) {
+			var e = el[i];
+			var a = find_child(e, "rect").attributes;
+			var ex = parseFloat(a.x.value);
+			var ew = parseFloat(a.width.value);
+			var upstack;
+			// Is it an ancestor
+			if (0 == 0) {
+				upstack = parseFloat(a.y.value) > ymin;
+			} else {
+				upstack = parseFloat(a.y.value) < ymin;
+			}
+			if (upstack) {
+				// Direct ancestor
+				if (ex <= xmin && (ex+ew+fudge) >= xmax) {
+					e.classList.add("parent");
+					zoom_parent(e);
+					update_text(e);
+				}
+				// not in current path
+				else
+					e.classList.add("hide");
+			}
+			// Children maybe
+			else {
+				// no common path
+				if (ex < xmin || ex + fudge >= xmax) {
+					e.classList.add("hide");
+				}
+				else {
+					zoom_child(e, xmin, ratio);
+					update_text(e);
+				}
+			}
+		}
+		search();
+	}
+	function unzoom() {
+		unzoombtn.classList.add("hide");
+		var el = document.getElementById("frames").children;
+		for(var i = 0; i < el.length; i++) {
+			el[i].classList.remove("parent");
+			el[i].classList.remove("hide");
+			zoom_reset(el[i]);
+			update_text(el[i]);
+		}
+		search();
+	}
+	function clearzoom() {
+		unzoom();
+
+		// remove zoom state
+		var params = get_params();
+		if (params.x) delete params.x;
+		if (params.y) delete params.y;
+		history.replaceState(null, null, parse_params(params));
+	}
+
+	// search
+	function toggle_ignorecase() {
+		ignorecase = !ignorecase;
+		if (ignorecase) {
+			ignorecaseBtn.classList.add("show");
+		} else {
+			ignorecaseBtn.classList.remove("show");
+		}
+		reset_search();
+		search();
+	}
+	function reset_search() {
+		var el = document.querySelectorAll("#frames rect");
+		for (var i = 0; i < el.length; i++) {
+			orig_load(el[i], "fill")
+		}
+		var params = get_params();
+		delete params.s;
+		history.replaceState(null, null, parse_params(params));
+	}
+	function search_prompt() {
+		if (!searching) {
+			var term = prompt("Enter a search term (regexp " +
+			    "allowed, eg: ^ext4_)"
+			    + (ignorecase ? ", ignoring case" : "")
+			    + "\nPress Ctrl-i to toggle case sensitivity", "");
+			if (term != null) search(term);
+		} else {
+			reset_search();
+			searching = 0;
+			currentSearchTerm = null;
+			searchbtn.classList.remove("show");
+			searchbtn.firstChild.nodeValue = "Search"
+			matchedtxt.classList.add("hide");
+			matchedtxt.firstChild.nodeValue = ""
+		}
+	}
+	function search(term) {
+		if (term) currentSearchTerm = term;
+
+		var re = new RegExp(currentSearchTerm, ignorecase ? 'i' : '');
+		var el = document.getElementById("frames").children;
+		var matches = new Object();
+		var maxwidth = 0;
+		for (var i = 0; i < el.length; i++) {
+			var e = el[i];
+			var func = g_to_func(e);
+			var rect = find_child(e, "rect");
+			if (func == null || rect == null)
+				continue;
+
+			// Save max width. Only works as we have a root frame
+			var w = parseFloat(rect.attributes.width.value);
+			if (w > maxwidth)
+				maxwidth = w;
+
+			if (func.match(re)) {
+				// highlight
+				var x = parseFloat(rect.attributes.x.value);
+				orig_save(rect, "fill");
+				rect.attributes.fill.value = "rgb(230,0,230)";
+
+				// remember matches
+				if (matches[x] == undefined) {
+					matches[x] = w;
+				} else {
+					if (w > matches[x]) {
+						// overwrite with parent
+						matches[x] = w;
+					}
+				}
+				searching = 1;
+			}
+		}
+		if (!searching)
+			return;
+		var params = get_params();
+		params.s = currentSearchTerm;
+		history.replaceState(null, null, parse_params(params));
+
+		searchbtn.classList.add("show");
+		searchbtn.firstChild.nodeValue = "Reset Search";
+
+		// calculate percent matched, excluding vertical overlap
+		var count = 0;
+		var lastx = -1;
+		var lastw = 0;
+		var keys = Array();
+		for (k in matches) {
+			if (matches.hasOwnProperty(k))
+				keys.push(k);
+		}
+		// sort the matched frames by their x location
+		// ascending, then width descending
+		keys.sort(function(a, b){
+			return a - b;
+		});
+		// Step through frames saving only the biggest bottom-up frames
+		// thanks to the sort order. This relies on the tree property
+		// where children are always smaller than their parents.
+		var fudge = 0.0001;	// JavaScript floating point
+		for (var k in keys) {
+			var x = parseFloat(keys[k]);
+			var w = matches[keys[k]];
+			if (x >= lastx + lastw - fudge) {
+				count += w;
+				lastx = x;
+				lastw = w;
+			}
+		}
+		// display matched percent
+		matchedtxt.classList.remove("hide");
+		var pct = 100 * count / maxwidth;
+		if (pct != 100) pct = pct.toFixed(1)
+		matchedtxt.firstChild.nodeValue = "Matched: " + pct + "%";
+	}
+]]>
+</script>
+<rect x="0.0" y="0" width="1200.0" height="630.0" fill="url(#background)"  />
+<text id="title" x="600.00" y="24" >Flame Graph</text>
+<text id="details" x="10.00" y="613" > </text>
+<text id="unzoom" x="10.00" y="24" class="hide">Reset Zoom</text>
+<text id="search" x="1090.00" y="24" >Search</text>
+<text id="ignorecase" x="1174.00" y="24" >ic</text>
+<text id="matched" x="1090.00" y="613" > </text>
+<g id="frames">
+<g >
+<title>ep_poll (2 samples, 10.00%)</title><rect x="1013.0" y="277" width="118.0" height="15.0" fill="rgb(222,224,20)" rx="2" ry="2" />
+<text  x="1016.00" y="287.5" >ep_poll</text>
+</g>
+<g >
+<title>__fdget (1 samples, 5.00%)</title><rect x="954.0" y="277" width="59.0" height="15.0" fill="rgb(229,96,47)" rx="2" ry="2" />
+<text  x="957.00" y="287.5" >__fdget</text>
+</g>
+<g >
+<title>rw_verify_area (1 samples, 5.00%)</title><rect x="1131.0" y="277" width="59.0" height="15.0" fill="rgb(239,159,3)" rx="2" ry="2" />
+<text  x="1134.00" y="287.5" >rw_ver..</text>
+</g>
+<g >
+<title>[kube-apiserver] (1 samples, 5.00%)</title><rect x="541.0" y="165" width="59.0" height="15.0" fill="rgb(243,66,30)" rx="2" ry="2" />
+<text  x="544.00" y="175.5" >[kube-..</text>
+</g>
+<g >
+<title>all (20 samples, 100%)</title><rect x="10.0" y="581" width="1180.0" height="15.0" fill="rgb(222,198,27)" rx="2" ry="2" />
+<text  x="13.00" y="591.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (1 samples, 5.00%)</title><rect x="600.0" y="261" width="59.0" height="15.0" fill="rgb(216,154,36)" rx="2" ry="2" />
+<text  x="603.00" y="271.5" >entry_..</text>
+</g>
+<g >
+<title>[kube-apiserver] (16 samples, 80.00%)</title><rect x="246.0" y="389" width="944.0" height="15.0" fill="rgb(221,225,1)" rx="2" ry="2" />
+<text  x="249.00" y="399.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>[kube-apiserver] (20 samples, 100.00%)</title><rect x="10.0" y="549" width="1180.0" height="15.0" fill="rgb(209,56,3)" rx="2" ry="2" />
+<text  x="13.00" y="559.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>[kube-apiserver] (1 samples, 5.00%)</title><rect x="541.0" y="85" width="59.0" height="15.0" fill="rgb(218,155,38)" rx="2" ry="2" />
+<text  x="544.00" y="95.5" >[kube-..</text>
+</g>
+<g >
+<title>__x64_sys_epoll_pwait (1 samples, 5.00%)</title><rect x="718.0" y="309" width="59.0" height="15.0" fill="rgb(251,12,26)" rx="2" ry="2" />
+<text  x="721.00" y="319.5" >__x64_..</text>
+</g>
+<g >
+<title>[kube-apiserver] (1 samples, 5.00%)</title><rect x="541.0" y="53" width="59.0" height="15.0" fill="rgb(224,25,6)" rx="2" ry="2" />
+<text  x="544.00" y="63.5" >[kube-..</text>
+</g>
+<g >
+<title>x64_sys_call (1 samples, 5.00%)</title><rect x="600.0" y="229" width="59.0" height="15.0" fill="rgb(208,88,9)" rx="2" ry="2" />
+<text  x="603.00" y="239.5" >x64_sy..</text>
+</g>
+<g >
+<title>do_syscall_64 (3 samples, 15.00%)</title><rect x="718.0" y="341" width="177.0" height="15.0" fill="rgb(207,224,6)" rx="2" ry="2" />
+<text  x="721.00" y="351.5" >do_syscall_64</text>
+</g>
+<g >
+<title>[kube-apiserver] (1 samples, 5.00%)</title><rect x="541.0" y="117" width="59.0" height="15.0" fill="rgb(205,103,51)" rx="2" ry="2" />
+<text  x="544.00" y="127.5" >[kube-..</text>
+</g>
+<g >
+<title>futex_wait_queue (1 samples, 5.00%)</title><rect x="777.0" y="245" width="59.0" height="15.0" fill="rgb(247,78,2)" rx="2" ry="2" />
+<text  x="780.00" y="255.5" >futex_..</text>
+</g>
+<g >
+<title>[kube-apiserver] (1 samples, 5.00%)</title><rect x="541.0" y="149" width="59.0" height="15.0" fill="rgb(249,92,49)" rx="2" ry="2" />
+<text  x="544.00" y="159.5" >[kube-..</text>
+</g>
+<g >
+<title>tcp_recvmsg (1 samples, 5.00%)</title><rect x="600.0" y="117" width="59.0" height="15.0" fill="rgb(254,193,30)" rx="2" ry="2" />
+<text  x="603.00" y="127.5" >tcp_re..</text>
+</g>
+<g >
+<title>schedule (1 samples, 5.00%)</title><rect x="777.0" y="229" width="59.0" height="15.0" fill="rgb(224,193,4)" rx="2" ry="2" />
+<text  x="780.00" y="239.5" >schedule</text>
+</g>
+<g >
+<title>[kube-apiserver] (2 samples, 10.00%)</title><rect x="482.0" y="181" width="118.0" height="15.0" fill="rgb(248,228,39)" rx="2" ry="2" />
+<text  x="485.00" y="191.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>vfs_write (1 samples, 5.00%)</title><rect x="1131.0" y="293" width="59.0" height="15.0" fill="rgb(251,64,44)" rx="2" ry="2" />
+<text  x="1134.00" y="303.5" >vfs_wr..</text>
+</g>
+<g >
+<title>inet6_recvmsg (1 samples, 5.00%)</title><rect x="600.0" y="133" width="59.0" height="15.0" fill="rgb(247,3,43)" rx="2" ry="2" />
+<text  x="603.00" y="143.5" >inet6_..</text>
+</g>
+<g >
+<title>[kube-apiserver] (17 samples, 85.00%)</title><rect x="187.0" y="437" width="1003.0" height="15.0" fill="rgb(247,87,28)" rx="2" ry="2" />
+<text  x="190.00" y="447.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (1 samples, 5.00%)</title><rect x="659.0" y="325" width="59.0" height="15.0" fill="rgb(208,36,22)" rx="2" ry="2" />
+<text  x="662.00" y="335.5" >entry_..</text>
+</g>
+<g >
+<title>sock_recvmsg (1 samples, 5.00%)</title><rect x="600.0" y="149" width="59.0" height="15.0" fill="rgb(219,83,23)" rx="2" ry="2" />
+<text  x="603.00" y="159.5" >sock_r..</text>
+</g>
+<g >
+<title>__schedule (1 samples, 5.00%)</title><rect x="718.0" y="197" width="59.0" height="15.0" fill="rgb(230,198,28)" rx="2" ry="2" />
+<text  x="721.00" y="207.5" >__sche..</text>
+</g>
+<g >
+<title>_raw_spin_unlock_irqrestore (1 samples, 5.00%)</title><rect x="659.0" y="213" width="59.0" height="15.0" fill="rgb(207,33,0)" rx="2" ry="2" />
+<text  x="662.00" y="223.5" >_raw_s..</text>
+</g>
+<g >
+<title>[kube-apiserver] (3 samples, 15.00%)</title><rect x="423.0" y="245" width="177.0" height="15.0" fill="rgb(214,40,34)" rx="2" ry="2" />
+<text  x="426.00" y="255.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>[kube-apiserver] (20 samples, 100.00%)</title><rect x="10.0" y="533" width="1180.0" height="15.0" fill="rgb(243,79,34)" rx="2" ry="2" />
+<text  x="13.00" y="543.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>[kube-apiserver] (2 samples, 10.00%)</title><rect x="482.0" y="213" width="118.0" height="15.0" fill="rgb(217,215,48)" rx="2" ry="2" />
+<text  x="485.00" y="223.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (3 samples, 15.00%)</title><rect x="718.0" y="357" width="177.0" height="15.0" fill="rgb(254,198,42)" rx="2" ry="2" />
+<text  x="721.00" y="367.5" >entry_SYSCALL_64_after_..</text>
+</g>
+<g >
+<title>schedule_hrtimeout_range_clock (1 samples, 5.00%)</title><rect x="718.0" y="229" width="59.0" height="15.0" fill="rgb(217,42,29)" rx="2" ry="2" />
+<text  x="721.00" y="239.5" >schedu..</text>
+</g>
+<g >
+<title>schedule (2 samples, 10.00%)</title><rect x="1013.0" y="229" width="118.0" height="15.0" fill="rgb(227,44,44)" rx="2" ry="2" />
+<text  x="1016.00" y="239.5" >schedule</text>
+</g>
+<g >
+<title>schedule (1 samples, 5.00%)</title><rect x="718.0" y="213" width="59.0" height="15.0" fill="rgb(249,81,32)" rx="2" ry="2" />
+<text  x="721.00" y="223.5" >schedule</text>
+</g>
+<g >
+<title>__futex_wait (1 samples, 5.00%)</title><rect x="777.0" y="261" width="59.0" height="15.0" fill="rgb(253,174,14)" rx="2" ry="2" />
+<text  x="780.00" y="271.5" >__fute..</text>
+</g>
+<g >
+<title>[kube-apiserver] (1 samples, 5.00%)</title><rect x="541.0" y="69" width="59.0" height="15.0" fill="rgb(221,138,27)" rx="2" ry="2" />
+<text  x="544.00" y="79.5" >[kube-..</text>
+</g>
+<g >
+<title>schedule_hrtimeout_range_clock (2 samples, 10.00%)</title><rect x="1013.0" y="245" width="118.0" height="15.0" fill="rgb(208,45,13)" rx="2" ry="2" />
+<text  x="1016.00" y="255.5" >schedule_hrtim..</text>
+</g>
+<g >
+<title>[kube-apiserver] (16 samples, 80.00%)</title><rect x="246.0" y="405" width="944.0" height="15.0" fill="rgb(253,186,14)" rx="2" ry="2" />
+<text  x="249.00" y="415.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>do_epoll_pwait.part.0 (1 samples, 5.00%)</title><rect x="718.0" y="293" width="59.0" height="15.0" fill="rgb(209,27,37)" rx="2" ry="2" />
+<text  x="721.00" y="303.5" >do_epo..</text>
+</g>
+<g >
+<title>[kube-apiserver] (1 samples, 5.00%)</title><rect x="541.0" y="37" width="59.0" height="15.0" fill="rgb(253,147,37)" rx="2" ry="2" />
+<text  x="544.00" y="47.5" >[kube-..</text>
+</g>
+<g >
+<title>apparmor_file_permission (1 samples, 5.00%)</title><rect x="1131.0" y="245" width="59.0" height="15.0" fill="rgb(242,95,40)" rx="2" ry="2" />
+<text  x="1134.00" y="255.5" >apparm..</text>
+</g>
+<g >
+<title>[kube-apiserver] (1 samples, 5.00%)</title><rect x="541.0" y="133" width="59.0" height="15.0" fill="rgb(220,26,17)" rx="2" ry="2" />
+<text  x="544.00" y="143.5" >[kube-..</text>
+</g>
+<g >
+<title>do_syscall_64 (1 samples, 5.00%)</title><rect x="600.0" y="245" width="59.0" height="15.0" fill="rgb(212,207,13)" rx="2" ry="2" />
+<text  x="603.00" y="255.5" >do_sys..</text>
+</g>
+<g >
+<title>__x64_sys_epoll_pwait (4 samples, 20.00%)</title><rect x="895.0" y="325" width="236.0" height="15.0" fill="rgb(215,2,37)" rx="2" ry="2" />
+<text  x="898.00" y="335.5" >__x64_sys_epoll_pwait</text>
+</g>
+<g >
+<title>_raw_spin_unlock_irqrestore (1 samples, 5.00%)</title><rect x="836.0" y="245" width="59.0" height="15.0" fill="rgb(242,89,31)" rx="2" ry="2" />
+<text  x="839.00" y="255.5" >_raw_s..</text>
+</g>
+<g >
+<title>[kube-apiserver] (19 samples, 95.00%)</title><rect x="69.0" y="485" width="1121.0" height="15.0" fill="rgb(220,179,3)" rx="2" ry="2" />
+<text  x="72.00" y="495.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>sock_rfree (1 samples, 5.00%)</title><rect x="600.0" y="85" width="59.0" height="15.0" fill="rgb(211,58,25)" rx="2" ry="2" />
+<text  x="603.00" y="95.5" >sock_r..</text>
+</g>
+<g >
+<title>__x64_sys_write (1 samples, 5.00%)</title><rect x="1131.0" y="325" width="59.0" height="15.0" fill="rgb(252,203,11)" rx="2" ry="2" />
+<text  x="1134.00" y="335.5" >__x64_..</text>
+</g>
+<g >
+<title>ksys_write (1 samples, 5.00%)</title><rect x="1131.0" y="309" width="59.0" height="15.0" fill="rgb(250,92,21)" rx="2" ry="2" />
+<text  x="1134.00" y="319.5" >ksys_w..</text>
+</g>
+<g >
+<title>ksys_write (1 samples, 5.00%)</title><rect x="836.0" y="293" width="59.0" height="15.0" fill="rgb(211,132,4)" rx="2" ry="2" />
+<text  x="839.00" y="303.5" >ksys_w..</text>
+</g>
+<g >
+<title>x64_sys_call (3 samples, 15.00%)</title><rect x="718.0" y="325" width="177.0" height="15.0" fill="rgb(222,135,6)" rx="2" ry="2" />
+<text  x="721.00" y="335.5" >x64_sys_call</text>
+</g>
+<g >
+<title>[kube-apiserver] (20 samples, 100.00%)</title><rect x="10.0" y="501" width="1180.0" height="15.0" fill="rgb(217,24,6)" rx="2" ry="2" />
+<text  x="13.00" y="511.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>do_epoll_pwait.part.0 (3 samples, 15.00%)</title><rect x="954.0" y="309" width="177.0" height="15.0" fill="rgb(207,205,42)" rx="2" ry="2" />
+<text  x="957.00" y="319.5" >do_epoll_pwait.part.0</text>
+</g>
+<g >
+<title>[kube-apiserver] (2 samples, 10.00%)</title><rect x="482.0" y="229" width="118.0" height="15.0" fill="rgb(220,12,11)" rx="2" ry="2" />
+<text  x="485.00" y="239.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>do_syscall_64 (5 samples, 25.00%)</title><rect x="895.0" y="357" width="295.0" height="15.0" fill="rgb(210,150,30)" rx="2" ry="2" />
+<text  x="898.00" y="367.5" >do_syscall_64</text>
+</g>
+<g >
+<title>[kube-apiserver] (2 samples, 10.00%)</title><rect x="482.0" y="197" width="118.0" height="15.0" fill="rgb(209,120,20)" rx="2" ry="2" />
+<text  x="485.00" y="207.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>do_epoll_wait (1 samples, 5.00%)</title><rect x="718.0" y="277" width="59.0" height="15.0" fill="rgb(236,79,42)" rx="2" ry="2" />
+<text  x="721.00" y="287.5" >do_epo..</text>
+</g>
+<g >
+<title>[kube-apiserver] (4 samples, 20.00%)</title><rect x="423.0" y="277" width="236.0" height="15.0" fill="rgb(207,58,15)" rx="2" ry="2" />
+<text  x="426.00" y="287.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>sock_read_iter (1 samples, 5.00%)</title><rect x="600.0" y="165" width="59.0" height="15.0" fill="rgb(223,211,8)" rx="2" ry="2" />
+<text  x="603.00" y="175.5" >sock_r..</text>
+</g>
+<g >
+<title>finish_task_switch.isra.0 (2 samples, 10.00%)</title><rect x="1013.0" y="197" width="118.0" height="15.0" fill="rgb(248,113,14)" rx="2" ry="2" />
+<text  x="1016.00" y="207.5" >finish_task_sw..</text>
+</g>
+<g >
+<title>ksys_read (1 samples, 5.00%)</title><rect x="600.0" y="197" width="59.0" height="15.0" fill="rgb(224,216,18)" rx="2" ry="2" />
+<text  x="603.00" y="207.5" >ksys_r..</text>
+</g>
+<g >
+<title>[kube-apiserver] (17 samples, 85.00%)</title><rect x="187.0" y="453" width="1003.0" height="15.0" fill="rgb(225,110,51)" rx="2" ry="2" />
+<text  x="190.00" y="463.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>[kube-apiserver] (5 samples, 25.00%)</title><rect x="364.0" y="325" width="295.0" height="15.0" fill="rgb(241,77,5)" rx="2" ry="2" />
+<text  x="367.00" y="335.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>pipe_write (1 samples, 5.00%)</title><rect x="836.0" y="261" width="59.0" height="15.0" fill="rgb(238,128,11)" rx="2" ry="2" />
+<text  x="839.00" y="271.5" >pipe_w..</text>
+</g>
+<g >
+<title>[kube-apiserver] (17 samples, 85.00%)</title><rect x="187.0" y="469" width="1003.0" height="15.0" fill="rgb(253,198,14)" rx="2" ry="2" />
+<text  x="190.00" y="479.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>[kube-apiserver] (20 samples, 100.00%)</title><rect x="10.0" y="517" width="1180.0" height="15.0" fill="rgb(236,172,38)" rx="2" ry="2" />
+<text  x="13.00" y="527.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>kube-apiserver (20 samples, 100.00%)</title><rect x="10.0" y="565" width="1180.0" height="15.0" fill="rgb(229,56,6)" rx="2" ry="2" />
+<text  x="13.00" y="575.5" >kube-apiserver</text>
+</g>
+<g >
+<title>__schedule (1 samples, 5.00%)</title><rect x="777.0" y="213" width="59.0" height="15.0" fill="rgb(223,207,19)" rx="2" ry="2" />
+<text  x="780.00" y="223.5" >__sche..</text>
+</g>
+<g >
+<title>__schedule (2 samples, 10.00%)</title><rect x="1013.0" y="213" width="118.0" height="15.0" fill="rgb(225,161,26)" rx="2" ry="2" />
+<text  x="1016.00" y="223.5" >__schedule</text>
+</g>
+<g >
+<title>do_futex (1 samples, 5.00%)</title><rect x="659.0" y="261" width="59.0" height="15.0" fill="rgb(246,136,24)" rx="2" ry="2" />
+<text  x="662.00" y="271.5" >do_futex</text>
+</g>
+<g >
+<title>do_syscall_64 (1 samples, 5.00%)</title><rect x="659.0" y="309" width="59.0" height="15.0" fill="rgb(217,148,50)" rx="2" ry="2" />
+<text  x="662.00" y="319.5" >do_sys..</text>
+</g>
+<g >
+<title>wake_up_q (1 samples, 5.00%)</title><rect x="659.0" y="229" width="59.0" height="15.0" fill="rgb(205,68,46)" rx="2" ry="2" />
+<text  x="662.00" y="239.5" >wake_u..</text>
+</g>
+<g >
+<title>ep_poll (1 samples, 5.00%)</title><rect x="718.0" y="261" width="59.0" height="15.0" fill="rgb(238,163,23)" rx="2" ry="2" />
+<text  x="721.00" y="271.5" >ep_poll</text>
+</g>
+<g >
+<title>__x64_sys_futex (1 samples, 5.00%)</title><rect x="659.0" y="277" width="59.0" height="15.0" fill="rgb(224,158,30)" rx="2" ry="2" />
+<text  x="662.00" y="287.5" >__x64_..</text>
+</g>
+<g >
+<title>[kube-apiserver] (6 samples, 30.00%)</title><rect x="364.0" y="341" width="354.0" height="15.0" fill="rgb(213,157,38)" rx="2" ry="2" />
+<text  x="367.00" y="351.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>[kube-apiserver] (4 samples, 20.00%)</title><rect x="423.0" y="309" width="236.0" height="15.0" fill="rgb(254,65,20)" rx="2" ry="2" />
+<text  x="426.00" y="319.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>[kube-apiserver] (17 samples, 85.00%)</title><rect x="187.0" y="421" width="1003.0" height="15.0" fill="rgb(242,147,54)" rx="2" ry="2" />
+<text  x="190.00" y="431.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>schedule_hrtimeout_range (2 samples, 10.00%)</title><rect x="1013.0" y="261" width="118.0" height="15.0" fill="rgb(230,228,40)" rx="2" ry="2" />
+<text  x="1016.00" y="271.5" >schedule_hrtim..</text>
+</g>
+<g >
+<title>__x64_sys_write (1 samples, 5.00%)</title><rect x="836.0" y="309" width="59.0" height="15.0" fill="rgb(217,151,54)" rx="2" ry="2" />
+<text  x="839.00" y="319.5" >__x64_..</text>
+</g>
+<g >
+<title>__x64_sys_read (1 samples, 5.00%)</title><rect x="600.0" y="213" width="59.0" height="15.0" fill="rgb(237,150,34)" rx="2" ry="2" />
+<text  x="603.00" y="223.5" >__x64_..</text>
+</g>
+<g >
+<title>[kube-apiserver] (10 samples, 50.00%)</title><rect x="305.0" y="373" width="590.0" height="15.0" fill="rgb(231,204,52)" rx="2" ry="2" />
+<text  x="308.00" y="383.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>vfs_read (1 samples, 5.00%)</title><rect x="600.0" y="181" width="59.0" height="15.0" fill="rgb(210,81,46)" rx="2" ry="2" />
+<text  x="603.00" y="191.5" >vfs_read</text>
+</g>
+<g >
+<title>[kube-apiserver] (4 samples, 20.00%)</title><rect x="423.0" y="293" width="236.0" height="15.0" fill="rgb(235,197,54)" rx="2" ry="2" />
+<text  x="426.00" y="303.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>__x64_sys_futex (1 samples, 5.00%)</title><rect x="777.0" y="309" width="59.0" height="15.0" fill="rgb(248,109,3)" rx="2" ry="2" />
+<text  x="780.00" y="319.5" >__x64_..</text>
+</g>
+<g >
+<title>schedule_hrtimeout_range (1 samples, 5.00%)</title><rect x="718.0" y="245" width="59.0" height="15.0" fill="rgb(244,217,17)" rx="2" ry="2" />
+<text  x="721.00" y="255.5" >schedu..</text>
+</g>
+<g >
+<title>finish_task_switch.isra.0 (1 samples, 5.00%)</title><rect x="718.0" y="181" width="59.0" height="15.0" fill="rgb(252,140,14)" rx="2" ry="2" />
+<text  x="721.00" y="191.5" >finish..</text>
+</g>
+<g >
+<title>__sk_mem_reduce_allocated (1 samples, 5.00%)</title><rect x="600.0" y="69" width="59.0" height="15.0" fill="rgb(215,121,3)" rx="2" ry="2" />
+<text  x="603.00" y="79.5" >__sk_m..</text>
+</g>
+<g >
+<title>[kube-apiserver] (3 samples, 15.00%)</title><rect x="423.0" y="261" width="177.0" height="15.0" fill="rgb(251,93,18)" rx="2" ry="2" />
+<text  x="426.00" y="271.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>finish_task_switch.isra.0 (1 samples, 5.00%)</title><rect x="777.0" y="197" width="59.0" height="15.0" fill="rgb(214,146,14)" rx="2" ry="2" />
+<text  x="780.00" y="207.5" >finish..</text>
+</g>
+<g >
+<title>futex_wait (1 samples, 5.00%)</title><rect x="777.0" y="277" width="59.0" height="15.0" fill="rgb(245,20,14)" rx="2" ry="2" />
+<text  x="780.00" y="287.5" >futex_..</text>
+</g>
+<g >
+<title>do_futex (1 samples, 5.00%)</title><rect x="777.0" y="293" width="59.0" height="15.0" fill="rgb(230,132,11)" rx="2" ry="2" />
+<text  x="780.00" y="303.5" >do_futex</text>
+</g>
+<g >
+<title>do_epoll_wait (3 samples, 15.00%)</title><rect x="954.0" y="293" width="177.0" height="15.0" fill="rgb(219,25,16)" rx="2" ry="2" />
+<text  x="957.00" y="303.5" >do_epoll_wait</text>
+</g>
+<g >
+<title>futex_wake (1 samples, 5.00%)</title><rect x="659.0" y="245" width="59.0" height="15.0" fill="rgb(211,71,16)" rx="2" ry="2" />
+<text  x="662.00" y="255.5" >futex_..</text>
+</g>
+<g >
+<title>[kube-apiserver] (7 samples, 35.00%)</title><rect x="305.0" y="357" width="413.0" height="15.0" fill="rgb(253,216,19)" rx="2" ry="2" />
+<text  x="308.00" y="367.5" >[kube-apiserver]</text>
+</g>
+<g >
+<title>x64_sys_call (1 samples, 5.00%)</title><rect x="659.0" y="293" width="59.0" height="15.0" fill="rgb(243,28,31)" rx="2" ry="2" />
+<text  x="662.00" y="303.5" >x64_sy..</text>
+</g>
+<g >
+<title>x64_sys_call (5 samples, 25.00%)</title><rect x="895.0" y="341" width="295.0" height="15.0" fill="rgb(252,210,32)" rx="2" ry="2" />
+<text  x="898.00" y="351.5" >x64_sys_call</text>
+</g>
+<g >
+<title>mem_cgroup_uncharge_skmem (1 samples, 5.00%)</title><rect x="600.0" y="53" width="59.0" height="15.0" fill="rgb(210,47,40)" rx="2" ry="2" />
+<text  x="603.00" y="63.5" >mem_cg..</text>
+</g>
+<g >
+<title>vfs_write (1 samples, 5.00%)</title><rect x="836.0" y="277" width="59.0" height="15.0" fill="rgb(211,89,8)" rx="2" ry="2" />
+<text  x="839.00" y="287.5" >vfs_wr..</text>
+</g>
+<g >
+<title>tcp_recvmsg_locked (1 samples, 5.00%)</title><rect x="600.0" y="101" width="59.0" height="15.0" fill="rgb(208,166,34)" rx="2" ry="2" />
+<text  x="603.00" y="111.5" >tcp_re..</text>
+</g>
+<g >
+<title>security_file_permission (1 samples, 5.00%)</title><rect x="1131.0" y="261" width="59.0" height="15.0" fill="rgb(223,133,8)" rx="2" ry="2" />
+<text  x="1134.00" y="271.5" >securi..</text>
+</g>
+<g >
+<title>[kube-apiserver] (1 samples, 5.00%)</title><rect x="541.0" y="101" width="59.0" height="15.0" fill="rgb(226,192,1)" rx="2" ry="2" />
+<text  x="544.00" y="111.5" >[kube-..</text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (5 samples, 25.00%)</title><rect x="895.0" y="373" width="295.0" height="15.0" fill="rgb(236,88,43)" rx="2" ry="2" />
+<text  x="898.00" y="383.5" >entry_SYSCALL_64_after_hwframe</text>
+</g>
+</g>
+</svg>

--- a/manifests/etcd.yaml
+++ b/manifests/etcd.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: etcd
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+    - name: etcd
+      image: docker.io/hubimage/registry-k8s-io-etcd:3.5.9-0
+      command:
+        - etcd
+        - --advertise-client-urls=http://127.0.0.1:2379
+        - --listen-client-urls=http://0.0.0.0:2379
+        - --data-dir=/etcd
+        - --listen-peer-urls=http://0.0.0.0:2380
+        - --initial-cluster=default=http://127.0.0.1:2380
+        - --initial-advertise-peer-urls=http://127.0.0.1:2380
+        - --initial-cluster-state=new
+        - --initial-cluster-token=test-token
+      volumeMounts:
+        - name: etcd-data
+          mountPath: /etcd
+  volumes:
+    - name: etcd-data
+      hostPath:
+        path: /var/lib/etcd

--- a/manifests/kube-apiserver.yaml
+++ b/manifests/kube-apiserver.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+    - name: kube-apiserver
+      image: registry.k8s.io/kube-apiserver:v1.30.0
+      command:
+        - kube-apiserver
+        - --etcd-servers=http://127.0.0.1:2379
+        - --service-cluster-ip-range=10.0.0.0/24
+        - --bind-address=0.0.0.0
+        - --secure-port=6443
+        - --advertise-address=127.0.0.1
+        - --authorization-mode=AlwaysAllow
+        - --token-auth-file=/etc/kubernetes/token.csv
+        - --enable-priority-and-fairness=false
+        - --allow-privileged=true
+        - --profiling=false
+        - --storage-backend=etcd3
+        - --storage-media-type=application/json
+        - --v=0
+        - --service-account-issuer=https://kubernetes.default.svc.cluster.local
+        - --service-account-key-file=/etc/kubernetes/sa.pub
+        - --service-account-signing-key-file=/etc/kubernetes/sa.key
+      volumeMounts:
+        - name: config
+          mountPath: /etc/kubernetes
+  volumes:
+    - name: config
+      hostPath:
+        path: /tmp

--- a/manifests/kube-controller-manager.yaml
+++ b/manifests/kube-controller-manager.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+    - name: kube-controller-manager
+      image: k8s.gcr.io/kube-controller-manager:v1.29.0
+      command:
+        - kube-controller-manager
+      args:
+        - --kubeconfig=/var/lib/kubelet/kubeconfig
+        - --leader-elect=false
+        - --service-cluster-ip-range=10.0.0.0/24
+        - --cluster-name=kubernetes
+        - --root-ca-file=/var/lib/kubelet/ca.crt
+        - --service-account-private-key-file=/tmp/sa.key
+        - --use-service-account-credentials=true
+        - --v=2
+      volumeMounts:
+        - name: config
+          mountPath: /var/lib/kubelet
+        - name: sa
+          mountPath: /tmp
+  volumes:
+    - name: config
+      hostPath:
+        path: /var/lib/kubelet
+    - name: sa
+      hostPath:
+        path: /tmp

--- a/manifests/kube-scheduler.yaml
+++ b/manifests/kube-scheduler.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-scheduler
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+    - name: kube-scheduler
+      image: registry.k8s.io/kube-scheduler:v1.30.0
+      command:
+        - kube-scheduler
+        - --kubeconfig=/etc/kubernetes/kubeconfig
+        - --leader-elect=false
+        - --v=2
+        - --bind-address=0.0.0.0
+      volumeMounts:
+        - name: config
+          mountPath: /etc/kubernetes
+  volumes:
+    - name: config
+      hostPath:
+        path: /var/lib/kubelet

--- a/setup-static-pods.sh
+++ b/setup-static-pods.sh
@@ -338,7 +338,7 @@ start() {
             --pod-infra-container-image=registry.k8s.io/pause:3.10 \
             --node-ip=$HOST_IP \
             --cgroup-driver=cgroupfs \
-            --max-pods=4  \
+            --max-pods=7  \
             --v=1 &
     fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -306,7 +306,7 @@ start() {
             --pod-infra-container-image=registry.k8s.io/pause:3.10 \
             --node-ip=$HOST_IP \
             --cgroup-driver=cgroupfs \
-            --max-pods=4  \
+            --max-pods=7  \
             --v=1 &
     fi
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added static Pod manifests for etcd, kube-apiserver, kube-controller-manager, kube-scheduler, and a privileged debug pod.
  - Added a setup script to provision a control plane and a helper script to manage static pods.

- **Documentation**
  - Added a step-by-step static pods guide.
  - Updated README: kubelet maxPods example, deployment replicas=3, and removed cloud-provider flags in examples.

- **Chores**
  - Updated .gitignore to exclude kubebuilder and etcd artifacts.
  - Removed cloud-provider=external flags and increased kubelet maxPods to 7 in startup scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->